### PR TITLE
Add FCM wake whitelist settings page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,7 @@
 .externalNativeBuild
 .cxx
 local.properties
+*.jks
+*.keystore
+*.p12
 /.idea/*

--- a/HyperFCMLive/build.gradle
+++ b/HyperFCMLive/build.gradle
@@ -79,7 +79,7 @@ base {
 dependencies {
     compileOnly 'androidx.annotation:annotation:1.10.0'
     compileOnly 'io.github.libxposed:api:102.0.0'
-//    implementation 'io.github.libxposed:service:102.0.0'
+    implementation 'io.github.libxposed:service:102.0.0'
     compileOnly project(":hiddenapi:stubs")
     implementation project(":hiddenapi:bridge")
 }

--- a/HyperFCMLive/src/main/AndroidManifest.xml
+++ b/HyperFCMLive/src/main/AndroidManifest.xml
@@ -2,10 +2,25 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Needed on Android 11+ (targetSdk >= 30): package visibility filtering
+         otherwise hides most installed user apps from
+         getInstalledPackages()/getInstalledApplications(). -->
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
+
     <application
         android:description="@string/xposed_description"
         android:label="@string/app_name"
         android:supportsRtl="true"
         tools:ignore="AllowBackup,MissingApplicationIcon">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/AppListAdapter.java
+++ b/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/AppListAdapter.java
@@ -1,7 +1,10 @@
 package io.github.howard20181.hyperos.fcmlive;
 
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
+import android.os.Handler;
+import android.os.Looper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,6 +14,8 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class AppListAdapter extends BaseAdapter {
 
@@ -21,22 +26,26 @@ public class AppListAdapter extends BaseAdapter {
     public static class AppEntry {
         public final String packageName;
         public final String label;
-        public final Drawable icon;
+        public Drawable icon;   // loaded lazily, null until resolved
+        public volatile boolean iconLoading;
         public boolean checked;
 
-        public AppEntry(String packageName, String label, Drawable icon) {
+        public AppEntry(String packageName, String label) {
             this.packageName = packageName;
             this.label = label;
-            this.icon = icon;
         }
     }
 
     private final LayoutInflater inflater;
+    private final PackageManager pm;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final ExecutorService iconLoader = Executors.newFixedThreadPool(4);
     private final List<AppEntry> apps;
     private final OnCheckedChangeListener listener;
 
     public AppListAdapter(Context context, List<AppEntry> apps, OnCheckedChangeListener listener) {
         this.inflater = LayoutInflater.from(context);
+        this.pm = context.getPackageManager();
         this.apps = apps;
         this.listener = listener;
     }
@@ -71,9 +80,15 @@ public class AppListAdapter extends BaseAdapter {
             holder = (ViewHolder) convertView.getTag();
         }
         AppEntry app = getItem(position);
-        holder.icon.setImageDrawable(app.icon);
         holder.label.setText(app.label);
         holder.pkg.setText(app.packageName);
+        if (app.icon != null) {
+            holder.icon.setImageDrawable(app.icon);
+        } else {
+            // Placeholder while the icon loads off the main thread.
+            holder.icon.setImageResource(android.R.drawable.sym_def_app_icon);
+            loadIcon(app);
+        }
         holder.check.setOnCheckedChangeListener(null);
         holder.check.setChecked(app.checked);
         holder.check.setOnCheckedChangeListener((buttonView, isChecked) -> {
@@ -83,6 +98,28 @@ public class AppListAdapter extends BaseAdapter {
             }
         });
         return convertView;
+    }
+
+    /** Load an app icon off the main thread, then refresh the row once ready. */
+    private void loadIcon(final AppEntry app) {
+        if (app.iconLoading) {
+            return;
+        }
+        app.iconLoading = true;
+        iconLoader.execute(() -> {
+            Drawable d;
+            try {
+                d = pm.getApplicationIcon(app.packageName);
+            } catch (PackageManager.NameNotFoundException e) {
+                d = null;
+            }
+            final Drawable loaded = d;
+            app.iconLoading = false;
+            if (loaded != null) {
+                app.icon = loaded;
+                mainHandler.post(AppListAdapter.this::notifyDataSetChanged);
+            }
+        });
     }
 
     private static class ViewHolder {

--- a/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/AppListAdapter.java
+++ b/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/AppListAdapter.java
@@ -1,0 +1,94 @@
+package io.github.howard20181.hyperos.fcmlive;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.CheckBox;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import java.util.List;
+
+public class AppListAdapter extends BaseAdapter {
+
+    public interface OnCheckedChangeListener {
+        void onCheckedChanged(String packageName, boolean checked);
+    }
+
+    public static class AppEntry {
+        public final String packageName;
+        public final String label;
+        public final Drawable icon;
+        public boolean checked;
+
+        public AppEntry(String packageName, String label, Drawable icon) {
+            this.packageName = packageName;
+            this.label = label;
+            this.icon = icon;
+        }
+    }
+
+    private final LayoutInflater inflater;
+    private final List<AppEntry> apps;
+    private final OnCheckedChangeListener listener;
+
+    public AppListAdapter(Context context, List<AppEntry> apps, OnCheckedChangeListener listener) {
+        this.inflater = LayoutInflater.from(context);
+        this.apps = apps;
+        this.listener = listener;
+    }
+
+    @Override
+    public int getCount() {
+        return apps.size();
+    }
+
+    @Override
+    public AppEntry getItem(int position) {
+        return apps.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        ViewHolder holder;
+        if (convertView == null) {
+            convertView = inflater.inflate(R.layout.item_app, parent, false);
+            holder = new ViewHolder();
+            holder.icon = convertView.findViewById(R.id.app_icon);
+            holder.label = convertView.findViewById(R.id.app_label);
+            holder.pkg = convertView.findViewById(R.id.app_pkg);
+            holder.check = convertView.findViewById(R.id.app_check);
+            convertView.setTag(holder);
+        } else {
+            holder = (ViewHolder) convertView.getTag();
+        }
+        AppEntry app = getItem(position);
+        holder.icon.setImageDrawable(app.icon);
+        holder.label.setText(app.label);
+        holder.pkg.setText(app.packageName);
+        holder.check.setOnCheckedChangeListener(null);
+        holder.check.setChecked(app.checked);
+        holder.check.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            app.checked = isChecked;
+            if (listener != null) {
+                listener.onCheckedChanged(app.packageName, isChecked);
+            }
+        });
+        return convertView;
+    }
+
+    private static class ViewHolder {
+        ImageView icon;
+        TextView label;
+        TextView pkg;
+        CheckBox check;
+    }
+}

--- a/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Hooker.java
+++ b/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Hooker.java
@@ -15,6 +15,7 @@ import androidx.annotation.RequiresApi;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -30,6 +31,8 @@ public class Hooker extends XposedModule {
     private static final String GMS_PERSISTENT_PROCESS_NAME = "com.google.android.gms.persistent";
     private PackageClassLoader param;
     private final Set<String> hookedIds = new HashSet<>();
+    private Context systemContext;
+    private Context moduleContext;
 
     private record PackageClassLoader(String packageName, ClassLoader classLoader) {
     }
@@ -297,7 +300,10 @@ public class Hooker extends XposedModule {
                 if (callerPackageField.get(broadcastRecord) instanceof String callerPackage
                         && GMS_PACKAGE_NAME.equals(callerPackage) // BroadcastRecord.callerPackage nullable
                         && intentField.get(broadcastRecord) instanceof Intent intent
-                        && ACTION_REMOTE_INTENT.equals(intent.getAction())) {
+                        && ACTION_REMOTE_INTENT.equals(intent.getAction())
+                        // Only auto-start apps the user explicitly whitelisted.
+                        && intent.getPackage() instanceof String targetPackage
+                        && getFcmAllowlist().contains(targetPackage)) {
                     return true;
                 }
             } catch (Exception e) {
@@ -411,6 +417,56 @@ public class Hooker extends XposedModule {
         return powerExemptionManager;
     }
 
+    /**
+     * A Context in system_server. Used as the parent for
+     * {@code createPackageContext(Prefs.MODULE_PKG, 0)} so the hooks can read the
+     * module's SharedPreferences (the FCM wake whitelist) across processes.
+     */
+    private Context getSystemContext() {
+        if (systemContext == null) {
+            try {
+                // ActivityThread.currentApplication() is hidden; call via reflection.
+                Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
+                Method currentApplication = activityThreadClass.getMethod("currentApplication");
+                if (currentApplication.invoke(null) instanceof Context ctx) {
+                    systemContext = ctx;
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+        return systemContext;
+    }
+
+    private Context getModuleContext() {
+        if (moduleContext == null) {
+            Context sys = getSystemContext();
+            if (sys != null) {
+                try {
+                    moduleContext = sys.createPackageContext(Prefs.MODULE_PKG, 0);
+                } catch (Exception e) {
+                    log(Log.ERROR, TAG, "Failed to get module context", e);
+                }
+            }
+        }
+        return moduleContext;
+    }
+
+    /**
+     * Package names the user allows FCM to wake / auto-launch. Empty until the
+     * user picks apps in the module settings; apps not in this set are never woken.
+     */
+    private Set<String> getFcmAllowlist() {
+        Context ctx = getModuleContext();
+        if (ctx == null) {
+            return Collections.emptySet();
+        }
+        try {
+            return Prefs.readAllowlist(ctx);
+        } catch (Exception e) {
+            return Collections.emptySet();
+        }
+    }
+
     private void hookActivityManagerService(ClassLoader classLoader) throws ClassNotFoundException,
             NoSuchMethodException, NoSuchFieldException {
         var ActivityManagerServiceClass = classLoader.loadClass("com.android.server.am.ActivityManagerService");
@@ -493,15 +549,18 @@ public class Hooker extends XposedModule {
                         && getInvoker(getRecordMethod).invoke(chain.getThisObject(), chain.getArg(0)) instanceof Object app
                         && infoField.get(app) instanceof ApplicationInfo info
                         && GMS_PACKAGE_NAME.equals(info.packageName)) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-                            && intent.getPackage() instanceof String packageName
-                            && mContextField.get(chain.getThisObject()) instanceof Context mContext) {
-                        getPowerExemptionManager(mContext).addToTemporaryAllowList(
-                                packageName, 102 /* PowerExemptionManager.REASON_PUSH_MESSAGING_OVER_QUOTA */,
-                                "GOOGLE_C2DM", 2000);
-                    }
-                    if ((intent.getFlags() & Intent.FLAG_INCLUDE_STOPPED_PACKAGES) == 0) {
-                        intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
+                    // Only wake / auto-start apps the user explicitly whitelisted.
+                    if (intent.getPackage() instanceof String targetPackage
+                            && getFcmAllowlist().contains(targetPackage)) {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+                                && mContextField.get(chain.getThisObject()) instanceof Context mContext) {
+                            getPowerExemptionManager(mContext).addToTemporaryAllowList(
+                                    targetPackage, 102 /* PowerExemptionManager.REASON_PUSH_MESSAGING_OVER_QUOTA */,
+                                    "GOOGLE_C2DM", 2000);
+                        }
+                        if ((intent.getFlags() & Intent.FLAG_INCLUDE_STOPPED_PACKAGES) == 0) {
+                            intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
+                        }
                     }
                 }
             }

--- a/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Hooker.java
+++ b/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Hooker.java
@@ -459,10 +459,28 @@ public class Hooker extends XposedModule {
         }
     }
 
-    /** Called from hookSystemServer: load the allowlist and refresh on app updates. */
+    /** Called from hookSystemServer: load the initial allowlist at boot. */
     private void hookAllowlist() {
+        loadAllowlistFromRemotePrefs();
+    }
+
+    private boolean allowlistReceiverRegistered = false;
+
+    private Set<String> getFcmAllowlist() {
+        // Lazily register the refresh receiver on first real use. It can't be done
+        // in onSystemServerStarting because IActivityManager is null during early
+        // SystemServer startup, so registerReceiver would NPE. By the time any C2DM
+        // broadcast reaches here the system is fully up.
+        ensureAllowlistReceiver();
+        return new HashSet<>(sAllowlist);
+    }
+
+    /** Register the receiver that re-reads the allowlist when the app updates it. */
+    private void ensureAllowlistReceiver() {
+        if (allowlistReceiverRegistered) {
+            return;
+        }
         try {
-            loadAllowlistFromRemotePrefs();
             Context sys = getSystemContext();
             if (sys == null) {
                 return;
@@ -481,13 +499,10 @@ public class Hooker extends XposedModule {
             } else {
                 sys.registerReceiver(receiver, filter);
             }
+            allowlistReceiverRegistered = true;
         } catch (Exception e) {
-            log(Log.ERROR, TAG, "Failed to hook allowlist receiver", e);
+            log(Log.ERROR, TAG, "Failed to register allowlist receiver", e);
         }
-    }
-
-    private Set<String> getFcmAllowlist() {
-        return new HashSet<>(sAllowlist);
     }
 
     private void hookActivityManagerService(ClassLoader classLoader) throws ClassNotFoundException,

--- a/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Hooker.java
+++ b/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Hooker.java
@@ -1,8 +1,10 @@
 package io.github.howard20181.hyperos.fcmlive;
 
 import android.annotation.SuppressLint;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.ResolveInfo;
 import android.os.Build;
@@ -32,7 +34,6 @@ public class Hooker extends XposedModule {
     private PackageClassLoader param;
     private final Set<String> hookedIds = new HashSet<>();
     private Context systemContext;
-    private Context moduleContext;
 
     private record PackageClassLoader(String packageName, ClassLoader classLoader) {
     }
@@ -56,6 +57,11 @@ public class Hooker extends XposedModule {
     }
 
     private void hookSystemServer(ClassLoader classLoader) {
+        try {
+            hookAllowlist();
+        } catch (Exception t) {
+            log(Log.ERROR, TAG, "Failed to hook allowlist receiver", t);
+        }
         try {
             hookGreezeManagerService(classLoader);
         } catch (Exception t) {
@@ -418,9 +424,7 @@ public class Hooker extends XposedModule {
     }
 
     /**
-     * A Context in system_server. Used as the parent for
-     * {@code createPackageContext(Prefs.MODULE_PKG, 0)} so the hooks can read the
-     * module's SharedPreferences (the FCM wake whitelist) across processes.
+     * A Context in system_server (ActivityThread.currentApplication()).
      */
     private Context getSystemContext() {
         if (systemContext == null) {
@@ -437,34 +441,53 @@ public class Hooker extends XposedModule {
         return systemContext;
     }
 
-    private Context getModuleContext() {
-        if (moduleContext == null) {
-            Context sys = getSystemContext();
-            if (sys != null) {
-                try {
-                    moduleContext = sys.createPackageContext(Prefs.MODULE_PKG, 0);
-                } catch (Exception e) {
-                    log(Log.ERROR, TAG, "Failed to get module context", e);
-                }
-            }
+    /**
+     * Package names the user allows FCM to wake / auto-launch, kept in memory in
+     * system_server. Loaded from libxposed's cross-process remote preferences and
+     * refreshed whenever the app broadcasts {@link Prefs#ACTION_ALLOWLIST_CHANGED}.
+     */
+    private static volatile Set<String> sAllowlist = Collections.emptySet();
+
+    /** Re-read the allowlist from the shared remote preferences. */
+    private void loadAllowlistFromRemotePrefs() {
+        try {
+            Set<String> set = getRemotePreferences(Prefs.GROUP_CONFIG)
+                    .getStringSet(Prefs.KEY_ALLOWLIST, Collections.emptySet());
+            sAllowlist = set != null ? new HashSet<>(set) : new HashSet<>();
+        } catch (Exception e) {
+            log(Log.ERROR, TAG, "Failed to read remote allowlist", e);
         }
-        return moduleContext;
     }
 
-    /**
-     * Package names the user allows FCM to wake / auto-launch. Empty until the
-     * user picks apps in the module settings; apps not in this set are never woken.
-     */
-    private Set<String> getFcmAllowlist() {
-        Context ctx = getModuleContext();
-        if (ctx == null) {
-            return Collections.emptySet();
-        }
+    /** Called from hookSystemServer: load the allowlist and refresh on app updates. */
+    private void hookAllowlist() {
         try {
-            return Prefs.readAllowlist(ctx);
+            loadAllowlistFromRemotePrefs();
+            Context sys = getSystemContext();
+            if (sys == null) {
+                return;
+            }
+            BroadcastReceiver receiver = new BroadcastReceiver() {
+                @Override
+                public void onReceive(Context context, Intent intent) {
+                    if (Prefs.ACTION_ALLOWLIST_CHANGED.equals(intent.getAction())) {
+                        loadAllowlistFromRemotePrefs();
+                    }
+                }
+            };
+            IntentFilter filter = new IntentFilter(Prefs.ACTION_ALLOWLIST_CHANGED);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                sys.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED);
+            } else {
+                sys.registerReceiver(receiver, filter);
+            }
         } catch (Exception e) {
-            return Collections.emptySet();
+            log(Log.ERROR, TAG, "Failed to hook allowlist receiver", e);
         }
+    }
+
+    private Set<String> getFcmAllowlist() {
+        return new HashSet<>(sAllowlist);
     }
 
     private void hookActivityManagerService(ClassLoader classLoader) throws ClassNotFoundException,

--- a/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Hooker.java
+++ b/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Hooker.java
@@ -315,9 +315,9 @@ public class Hooker extends XposedModule {
                         && GMS_PACKAGE_NAME.equals(callerPackage) // BroadcastRecord.callerPackage nullable
                         && intentField.get(broadcastRecord) instanceof Intent intent
                         && ACTION_REMOTE_INTENT.equals(intent.getAction())
-                        // Only auto-start apps the user explicitly whitelisted.
+                        // Auto-start only apps the user whitelisted; empty list = all.
                         && intent.getPackage() instanceof String targetPackage
-                        && getFcmAllowlist().contains(targetPackage)) {
+                        && shouldWake(targetPackage)) {
                     return true;
                 }
             } catch (Exception e) {
@@ -483,6 +483,16 @@ public class Hooker extends XposedModule {
         return new HashSet<>(sAllowlist);
     }
 
+    /**
+     * Whether a target package should be woken / auto-started by FCM.
+     * An empty allowlist keeps the legacy behaviour (wake everything); once the
+     * user checks at least one app it becomes whitelist mode (only checked apps).
+     */
+    private boolean shouldWake(String targetPackage) {
+        Set<String> allowlist = getFcmAllowlist();
+        return allowlist.isEmpty() || allowlist.contains(targetPackage);
+    }
+
     /** Register the receiver that re-reads the allowlist when the app updates it. */
     private void ensureAllowlistReceiver() {
         if (allowlistReceiverRegistered) {
@@ -595,9 +605,9 @@ public class Hooker extends XposedModule {
                         && getInvoker(getRecordMethod).invoke(chain.getThisObject(), chain.getArg(0)) instanceof Object app
                         && infoField.get(app) instanceof ApplicationInfo info
                         && GMS_PACKAGE_NAME.equals(info.packageName)) {
-                    // Only wake / auto-start apps the user explicitly whitelisted.
+                    // Wake / auto-start only apps the user whitelisted; empty list = all.
                     if (intent.getPackage() instanceof String targetPackage
-                            && getFcmAllowlist().contains(targetPackage)) {
+                            && shouldWake(targetPackage)) {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
                                 && mContextField.get(chain.getThisObject()) instanceof Context mContext) {
                             getPowerExemptionManager(mContext).addToTemporaryAllowList(

--- a/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Hooker.java
+++ b/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Hooker.java
@@ -129,18 +129,31 @@ public class Hooker extends XposedModule {
 
     @Override
     public boolean onHotReloading(@NonNull HotReloadingParam param) {
+        // Hot reload of system_server hooks is unreliable; a full reboot is the
+        // supported path. We still support reload below, but advise rebooting.
+        log(Log.WARN, TAG, "Hot reload requested — a full reboot is recommended for reliability");
         param.setSavedInstanceState(this.param);
         return true;
     }
 
     @Override
     public void onHotReloaded(@NonNull HotReloadedParam param) {
-        var isSystemServer = param.isSystemServer();
+        // Clean reload: reset id bookkeeping and remove every previous hook so the
+        // re-setup below starts fresh. Without this, old handles were never unhooked
+        // (hookedIds accumulated across passes) and stacked duplicate hooks made the
+        // reload appear ineffective.
+        hookedIds.clear();
+        param.getOldHookHandles().forEach(h -> {
+            try {
+                h.unhook();
+            } catch (Throwable ignored) {
+            }
+        });
         if (param.getSavedInstanceState() instanceof PackageClassLoader(
                 String packageName, ClassLoader classLoader
         )) {
             try {
-                if (isSystemServer) {
+                if (param.isSystemServer()) {
                     hookSystemServer(classLoader);
                 } else {
                     hookPackage(packageName, classLoader);
@@ -149,11 +162,6 @@ public class Hooker extends XposedModule {
                 log(Log.ERROR, TAG, "Hot reload failed", tr);
             }
         }
-        param.getOldHookHandles().forEach(h -> {
-            if (!hookedIds.contains(h.getId())) {
-                h.unhook();
-            }
-        });
     }
 
     private void hookGreezeManagerService(ClassLoader classLoader)

--- a/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/MainActivity.java
+++ b/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/MainActivity.java
@@ -1,22 +1,25 @@
 package io.github.howard20181.hyperos.fcmlive;
 
 import android.app.Activity;
+import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.view.Menu;
-import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.ListView;
 import android.widget.SearchView;
-import android.widget.TextView;
+
+import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import io.github.libxposed.service.XposedService;
+import io.github.libxposed.service.XposedServiceHelper;
 
 /**
  * Settings screen: lets the user pick which apps FCM is allowed to wake /
@@ -31,6 +34,7 @@ public class MainActivity extends Activity implements SearchView.OnQueryTextList
     private SearchView searchView;
     // Don't show system apps by default; toggle to include them.
     private boolean showSystemApps = false;
+    private XposedService xposedService;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -38,7 +42,7 @@ public class MainActivity extends Activity implements SearchView.OnQueryTextList
         setContentView(R.layout.activity_main);
         setTitle(R.string.settings_title);
 
-        allowlist = Prefs.readAllowlist(this);
+        initXposedService();
 
         adapter = new AppListAdapter(this, filteredApps, (pkg, checked) -> {
             if (checked) {
@@ -46,7 +50,7 @@ public class MainActivity extends Activity implements SearchView.OnQueryTextList
             } else {
                 allowlist.remove(pkg);
             }
-            Prefs.writeAllowlist(this, allowlist);
+            updateAllowlist();
             // Re-sort so the just-toggled app moves to/from the top.
             for (AppListAdapter.AppEntry app : allApps) {
                 if (app.packageName.equals(pkg)) {
@@ -114,7 +118,7 @@ public class MainActivity extends Activity implements SearchView.OnQueryTextList
                 allowlist.add(app.packageName);
             }
         }
-        Prefs.writeAllowlist(this, allowlist);
+        updateAllowlist();
         if (adapter != null) {
             adapter.notifyDataSetChanged();
         }
@@ -130,15 +134,16 @@ public class MainActivity extends Activity implements SearchView.OnQueryTextList
     }
 
     private void sortApps() {
-        // Checked (allowlisted) apps first, then alphabetically by label,
-        // with package name as tiebreak.
-        allApps.sort((a, b) -> {
-            if (a.checked != b.checked) {
-                return a.checked ? -1 : 1;
-            }
-            int c = a.label.compareToIgnoreCase(b.label);
-            return c != 0 ? c : a.packageName.compareTo(b.packageName);
-        });
+        allApps.sort(MainActivity::compareEntries);
+    }
+
+    /** Checked (allowlisted) apps first, then alphabetically by label. */
+    private static int compareEntries(AppListAdapter.AppEntry a, AppListAdapter.AppEntry b) {
+        if (a.checked != b.checked) {
+            return a.checked ? -1 : 1;
+        }
+        int c = a.label.compareToIgnoreCase(b.label);
+        return c != 0 ? c : a.packageName.compareTo(b.packageName);
     }
 
     private boolean isSystemApp(ApplicationInfo ai) {
@@ -147,13 +152,105 @@ public class MainActivity extends Activity implements SearchView.OnQueryTextList
                 && (ai.flags & ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) == 0;
     }
 
+    /**
+     * Bind to the libxposed XposedService so we can read/write the cross-process
+     * remote preferences that the system_server hooks read from.
+     */
+    private void initXposedService() {
+        try {
+            XposedServiceHelper.registerListener(new XposedServiceHelper.OnServiceListener() {
+                @Override
+                public void onServiceBind(@NonNull XposedService service) {
+                    xposedService = service;
+                    runOnUiThread(() -> {
+                        reloadAllowlist();
+                        if (adapter != null) {
+                            adapter.notifyDataSetChanged();
+                        }
+                    });
+                }
+
+                @Override
+                public void onServiceDied(@NonNull XposedService service) {
+                    if (xposedService == service) {
+                        xposedService = null;
+                    }
+                }
+            });
+        } catch (Throwable e) {
+            // Xposed service unavailable; the UI just won't be able to persist.
+        }
+    }
+
+    private SharedPreferences remotePrefs() {
+        if (xposedService == null) {
+            return null;
+        }
+        try {
+            return xposedService.getRemotePreferences(Prefs.GROUP_CONFIG);
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    private void reloadAllowlist() {
+        SharedPreferences prefs = remotePrefs();
+        if (prefs == null) {
+            return;
+        }
+        allowlist = Prefs.readAllowlist(prefs);
+        for (AppListAdapter.AppEntry app : allApps) {
+            app.checked = allowlist.contains(app.packageName);
+        }
+        sortApps();
+        filterApps(searchView != null ? searchView.getQuery().toString() : "");
+    }
+
+    /** Persist the allowlist to remote prefs and tell system_server to refresh. */
+    private void updateAllowlist() {
+        SharedPreferences prefs = remotePrefs();
+        if (prefs == null) {
+            return;
+        }
+        Prefs.writeAllowlist(this, prefs, allowlist);
+    }
+
     private void loadApps() {
         // Query the package manager and load labels off the main thread so the
         // first open of the screen stays responsive. Icons are loaded lazily by
         // the adapter, so only the lightweight query/label work happens here.
         final boolean showSys = showSystemApps;
+        final Set<String> allow = new HashSet<>(allowlist);
         new Thread(() -> {
             PackageManager pm = getPackageManager();
+
+            // Phase 1: show the allowlisted apps immediately, resolved from the
+            // allowlist package names, so the user sees their selection without
+            // waiting for the full package query to finish.
+            java.util.List<AppListAdapter.AppEntry> selected = new ArrayList<>();
+            for (String pkg : allow) {
+                ApplicationInfo ai;
+                try {
+                    ai = pm.getApplicationInfo(pkg, 0);
+                } catch (PackageManager.NameNotFoundException e) {
+                    continue; // allowlisted app no longer installed
+                }
+                AppListAdapter.AppEntry entry =
+                        new AppListAdapter.AppEntry(pkg, ai.loadLabel(pm).toString());
+                entry.checked = true;
+                selected.add(entry);
+            }
+            selected.sort(MainActivity::compareEntries);
+            if (!selected.isEmpty()) {
+                runOnUiThread(() -> {
+                    allApps.clear();
+                    allApps.addAll(selected);
+                    filterApps(searchView != null ? searchView.getQuery().toString() : "");
+                    adapter.notifyDataSetChanged();
+                });
+            }
+
+            // Phase 2: full query, replacing with the complete sorted list.
             java.util.List<android.content.pm.PackageInfo> installed =
                     pm.getInstalledPackages(0);
             java.util.List<AppListAdapter.AppEntry> result = new ArrayList<>();
@@ -173,14 +270,7 @@ public class MainActivity extends Activity implements SearchView.OnQueryTextList
             for (AppListAdapter.AppEntry app : result) {
                 app.checked = allowlist.contains(app.packageName);
             }
-            // Checked (allowlisted) apps first, then label alphabetically.
-            result.sort((a, b) -> {
-                if (a.checked != b.checked) {
-                    return a.checked ? -1 : 1;
-                }
-                int c = a.label.compareToIgnoreCase(b.label);
-                return c != 0 ? c : a.packageName.compareTo(b.packageName);
-            });
+            result.sort(MainActivity::compareEntries);
             runOnUiThread(() -> {
                 allApps.clear();
                 allApps.addAll(result);

--- a/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/MainActivity.java
+++ b/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/MainActivity.java
@@ -29,7 +29,8 @@ public class MainActivity extends Activity implements SearchView.OnQueryTextList
     private Set<String> allowlist = new HashSet<>();
     private AppListAdapter adapter;
     private SearchView searchView;
-    private boolean showSystemApps = true;
+    // Don't show system apps by default; toggle to include them.
+    private boolean showSystemApps = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -38,7 +39,6 @@ public class MainActivity extends Activity implements SearchView.OnQueryTextList
         setTitle(R.string.settings_title);
 
         allowlist = Prefs.readAllowlist(this);
-        loadApps();
 
         adapter = new AppListAdapter(this, filteredApps, (pkg, checked) -> {
             if (checked) {
@@ -66,15 +66,16 @@ public class MainActivity extends Activity implements SearchView.OnQueryTextList
         cbSystemApps.setChecked(showSystemApps);
         cbSystemApps.setOnCheckedChangeListener((buttonView, isChecked) -> {
             showSystemApps = isChecked;
+            // loadApps runs off the main thread and refreshes the list on completion.
             loadApps();
-            filterApps(searchView.getQuery().toString());
-            adapter.notifyDataSetChanged();
         });
 
         Button selectAll = findViewById(R.id.btn_select_all);
         Button clearAll = findViewById(R.id.btn_clear_all);
         selectAll.setOnClickListener(v -> setAllChecked(true));
         clearAll.setOnClickListener(v -> setAllChecked(false));
+
+        loadApps();
     }
 
     @Override
@@ -147,34 +148,45 @@ public class MainActivity extends Activity implements SearchView.OnQueryTextList
     }
 
     private void loadApps() {
-        allApps.clear();
-        filteredApps.clear();
-        PackageManager pm = getPackageManager();
-        // Use getInstalledPackages instead of getInstalledApplications for better
-        // MIUI compatibility. On some MIUI versions, getInstalledApplications
-        // doesn't return all user-installed apps.
-        java.util.List<android.content.pm.PackageInfo> installed =
-                pm.getInstalledPackages(0);
-        for (android.content.pm.PackageInfo pi : installed) {
-            ApplicationInfo ai = pi.applicationInfo;
-            // Skip the module's own package (it's never FCM-targeted by GMS).
-            if (ai.packageName.equals(getPackageName())) {
-                continue;
+        // Query the package manager and load labels off the main thread so the
+        // first open of the screen stays responsive. Icons are loaded lazily by
+        // the adapter, so only the lightweight query/label work happens here.
+        final boolean showSys = showSystemApps;
+        new Thread(() -> {
+            PackageManager pm = getPackageManager();
+            java.util.List<android.content.pm.PackageInfo> installed =
+                    pm.getInstalledPackages(0);
+            java.util.List<AppListAdapter.AppEntry> result = new ArrayList<>();
+            for (android.content.pm.PackageInfo pi : installed) {
+                ApplicationInfo ai = pi.applicationInfo;
+                // Skip the module's own package (it's never FCM-targeted by GMS).
+                if (ai.packageName.equals(getPackageName())) {
+                    continue;
+                }
+                // By default, only show user apps. Toggle to show system apps.
+                if (!showSys && isSystemApp(ai)) {
+                    continue;
+                }
+                result.add(new AppListAdapter.AppEntry(
+                        ai.packageName, ai.loadLabel(pm).toString()));
             }
-            // By default, only show user apps. Toggle to show system apps.
-            if (!showSystemApps && isSystemApp(ai)) {
-                continue;
+            for (AppListAdapter.AppEntry app : result) {
+                app.checked = allowlist.contains(app.packageName);
             }
-            allApps.add(new AppListAdapter.AppEntry(
-                    ai.packageName,
-                    ai.loadLabel(pm).toString(),
-                    ai.loadIcon(pm)));
-        }
-        for (AppListAdapter.AppEntry app : allApps) {
-            app.checked = allowlist.contains(app.packageName);
-        }
-        sortApps();
-        // Initially show all apps
-        filteredApps.addAll(allApps);
+            // Checked (allowlisted) apps first, then label alphabetically.
+            result.sort((a, b) -> {
+                if (a.checked != b.checked) {
+                    return a.checked ? -1 : 1;
+                }
+                int c = a.label.compareToIgnoreCase(b.label);
+                return c != 0 ? c : a.packageName.compareTo(b.packageName);
+            });
+            runOnUiThread(() -> {
+                allApps.clear();
+                allApps.addAll(result);
+                filterApps(searchView != null ? searchView.getQuery().toString() : "");
+                adapter.notifyDataSetChanged();
+            });
+        }).start();
     }
 }

--- a/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/MainActivity.java
+++ b/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/MainActivity.java
@@ -1,0 +1,180 @@
+package io.github.howard20181.hyperos.fcmlive;
+
+import android.app.Activity;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.Menu;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.ListView;
+import android.widget.SearchView;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Settings screen: lets the user pick which apps FCM is allowed to wake /
+ * auto-launch (manual whitelist). Apps not checked are never woken.
+ */
+public class MainActivity extends Activity implements SearchView.OnQueryTextListener {
+
+    private final List<AppListAdapter.AppEntry> allApps = new ArrayList<>();
+    private final List<AppListAdapter.AppEntry> filteredApps = new ArrayList<>();
+    private Set<String> allowlist = new HashSet<>();
+    private AppListAdapter adapter;
+    private SearchView searchView;
+    private boolean showSystemApps = true;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+        setTitle(R.string.settings_title);
+
+        allowlist = Prefs.readAllowlist(this);
+        loadApps();
+
+        adapter = new AppListAdapter(this, filteredApps, (pkg, checked) -> {
+            if (checked) {
+                allowlist.add(pkg);
+            } else {
+                allowlist.remove(pkg);
+            }
+            Prefs.writeAllowlist(this, allowlist);
+            // Re-sort so the just-toggled app moves to/from the top.
+            for (AppListAdapter.AppEntry app : allApps) {
+                if (app.packageName.equals(pkg)) {
+                    app.checked = checked;
+                    break;
+                }
+            }
+            sortApps();
+            filterApps(searchView.getQuery().toString());
+        });
+        ((ListView) findViewById(R.id.app_list)).setAdapter(adapter);
+
+        searchView = findViewById(R.id.search_view);
+        searchView.setOnQueryTextListener(this);
+
+        CheckBox cbSystemApps = findViewById(R.id.cb_system_apps);
+        cbSystemApps.setChecked(showSystemApps);
+        cbSystemApps.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            showSystemApps = isChecked;
+            loadApps();
+            filterApps(searchView.getQuery().toString());
+            adapter.notifyDataSetChanged();
+        });
+
+        Button selectAll = findViewById(R.id.btn_select_all);
+        Button clearAll = findViewById(R.id.btn_clear_all);
+        selectAll.setOnClickListener(v -> setAllChecked(true));
+        clearAll.setOnClickListener(v -> setAllChecked(false));
+    }
+
+    @Override
+    public boolean onQueryTextSubmit(String query) {
+        return false;
+    }
+
+    @Override
+    public boolean onQueryTextChange(String newText) {
+        filterApps(newText);
+        return true;
+    }
+
+    private void filterApps(String query) {
+        filteredApps.clear();
+        if (TextUtils.isEmpty(query)) {
+            filteredApps.addAll(allApps);
+        } else {
+            String lower = query.toLowerCase();
+            for (AppListAdapter.AppEntry app : allApps) {
+                if (app.label.toLowerCase().contains(lower)
+                        || app.packageName.toLowerCase().contains(lower)) {
+                    filteredApps.add(app);
+                }
+            }
+        }
+        adapter.notifyDataSetChanged();
+    }
+
+    private void setAllChecked(boolean checked) {
+        allowlist = new HashSet<>();
+        // Apply to all apps, not just filtered ones
+        for (AppListAdapter.AppEntry app : allApps) {
+            app.checked = checked;
+            if (checked) {
+                allowlist.add(app.packageName);
+            }
+        }
+        Prefs.writeAllowlist(this, allowlist);
+        if (adapter != null) {
+            adapter.notifyDataSetChanged();
+        }
+    }
+
+    private void toggleSystemApps() {
+        showSystemApps = !showSystemApps;
+        loadApps();
+        filterApps(searchView != null ? searchView.getQuery().toString() : "");
+        if (adapter != null) {
+            adapter.notifyDataSetChanged();
+        }
+    }
+
+    private void sortApps() {
+        // Checked (allowlisted) apps first, then alphabetically by label,
+        // with package name as tiebreak.
+        allApps.sort((a, b) -> {
+            if (a.checked != b.checked) {
+                return a.checked ? -1 : 1;
+            }
+            int c = a.label.compareToIgnoreCase(b.label);
+            return c != 0 ? c : a.packageName.compareTo(b.packageName);
+        });
+    }
+
+    private boolean isSystemApp(ApplicationInfo ai) {
+        // System app: either installed in /system or updated system app
+        return (ai.flags & ApplicationInfo.FLAG_SYSTEM) != 0
+                && (ai.flags & ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) == 0;
+    }
+
+    private void loadApps() {
+        allApps.clear();
+        filteredApps.clear();
+        PackageManager pm = getPackageManager();
+        // Use getInstalledPackages instead of getInstalledApplications for better
+        // MIUI compatibility. On some MIUI versions, getInstalledApplications
+        // doesn't return all user-installed apps.
+        java.util.List<android.content.pm.PackageInfo> installed =
+                pm.getInstalledPackages(0);
+        for (android.content.pm.PackageInfo pi : installed) {
+            ApplicationInfo ai = pi.applicationInfo;
+            // Skip the module's own package (it's never FCM-targeted by GMS).
+            if (ai.packageName.equals(getPackageName())) {
+                continue;
+            }
+            // By default, only show user apps. Toggle to show system apps.
+            if (!showSystemApps && isSystemApp(ai)) {
+                continue;
+            }
+            allApps.add(new AppListAdapter.AppEntry(
+                    ai.packageName,
+                    ai.loadLabel(pm).toString(),
+                    ai.loadIcon(pm)));
+        }
+        for (AppListAdapter.AppEntry app : allApps) {
+            app.checked = allowlist.contains(app.packageName);
+        }
+        sortApps();
+        // Initially show all apps
+        filteredApps.addAll(allApps);
+    }
+}

--- a/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Prefs.java
+++ b/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Prefs.java
@@ -1,56 +1,44 @@
 package io.github.howard20181.hyperos.fcmlive;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 
-import java.io.File;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Configuration storage shared between the settings UI (runs in the module's own
- * process) and the Xposed hooks (run in system_server). Both read/write the same
- * SharedPreferences file; {@link #ensureReadable(Context)} makes it readable by
- * system_server which runs under a different uid.
+ * FCM wake allowlist, shared between the module's settings UI (app process) and
+ * the Xposed hooks (system_server) via libxposed's cross-process remote
+ * preferences ({@code XposedInterface.getRemotePreferences}).
+ *
+ * system_server cannot read the module's private files (SELinux MLS categories)
+ * and querying an on-demand provider is unreliable, so we use the framework's
+ * own cross-process prefs as the single source of truth. After writing, the app
+ * broadcasts {@link #ACTION_ALLOWLIST_CHANGED} so the system_server hook re-reads
+ * its in-memory copy.
  */
 public final class Prefs {
-    public static final String PREF_NAME = "config";
-    public static final String KEY_ALLOWLIST = "allowlist";
     public static final String MODULE_PKG = "io.github.howard20181.hyperos.fcmlive";
+    /** Remote prefs group shared by the app process and system_server. */
+    public static final String GROUP_CONFIG = "config";
+    public static final String KEY_ALLOWLIST = "allowlist";
+    /** Action the app broadcasts after writing, to refresh system_server. */
+    public static final String ACTION_ALLOWLIST_CHANGED = MODULE_PKG + ".ALLOWLIST_CHANGED";
 
     private Prefs() {
     }
 
-    public static SharedPreferences prefs(Context context) {
-        // MODE_MULTI_PROCESS: system_server re-reads the file when it changes
-        // (mtime) so the hooks pick up UI changes without restart.
-        return context.getSharedPreferences(PREF_NAME, Context.MODE_MULTI_PROCESS);
-    }
-
     /** Package names the user allows FCM to wake / auto-launch. */
-    public static Set<String> readAllowlist(Context context) {
-        Set<String> set = prefs(context).getStringSet(KEY_ALLOWLIST, Collections.emptySet());
+    public static Set<String> readAllowlist(SharedPreferences remotePrefs) {
+        Set<String> set = remotePrefs.getStringSet(KEY_ALLOWLIST, Collections.emptySet());
         return set != null ? new HashSet<>(set) : new HashSet<>();
     }
 
-    public static void writeAllowlist(Context context, Set<String> allowlist) {
-        // commit() (synchronous) so the file exists before ensureReadable() chmods it.
-        prefs(context).edit().putStringSet(KEY_ALLOWLIST, new HashSet<>(allowlist)).commit();
-        ensureReadable(context);
-    }
-
-    /**
-     * Best-effort: make the prefs file (and its parent directory) world-readable so
-     * the system_server hook (a different uid) can read the same config file.
-     */
-    public static void ensureReadable(Context context) {
-        try {
-            File sharedPrefs = new File(context.getDataDir(), "shared_prefs");
-            Runtime.getRuntime().exec(new String[]{"chmod", "711", sharedPrefs.getAbsolutePath()});
-            Runtime.getRuntime().exec(new String[]{"chmod", "644",
-                    new File(sharedPrefs, PREF_NAME + ".xml").getAbsolutePath()});
-        } catch (Exception ignored) {
-        }
+    public static void writeAllowlist(Context context, SharedPreferences remotePrefs,
+                                      Set<String> allowlist) {
+        remotePrefs.edit().putStringSet(KEY_ALLOWLIST, new HashSet<>(allowlist)).commit();
+        context.sendBroadcast(new Intent(ACTION_ALLOWLIST_CHANGED));
     }
 }

--- a/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Prefs.java
+++ b/HyperFCMLive/src/main/java/io/github/howard20181/hyperos/fcmlive/Prefs.java
@@ -1,0 +1,56 @@
+package io.github.howard20181.hyperos.fcmlive;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Configuration storage shared between the settings UI (runs in the module's own
+ * process) and the Xposed hooks (run in system_server). Both read/write the same
+ * SharedPreferences file; {@link #ensureReadable(Context)} makes it readable by
+ * system_server which runs under a different uid.
+ */
+public final class Prefs {
+    public static final String PREF_NAME = "config";
+    public static final String KEY_ALLOWLIST = "allowlist";
+    public static final String MODULE_PKG = "io.github.howard20181.hyperos.fcmlive";
+
+    private Prefs() {
+    }
+
+    public static SharedPreferences prefs(Context context) {
+        // MODE_MULTI_PROCESS: system_server re-reads the file when it changes
+        // (mtime) so the hooks pick up UI changes without restart.
+        return context.getSharedPreferences(PREF_NAME, Context.MODE_MULTI_PROCESS);
+    }
+
+    /** Package names the user allows FCM to wake / auto-launch. */
+    public static Set<String> readAllowlist(Context context) {
+        Set<String> set = prefs(context).getStringSet(KEY_ALLOWLIST, Collections.emptySet());
+        return set != null ? new HashSet<>(set) : new HashSet<>();
+    }
+
+    public static void writeAllowlist(Context context, Set<String> allowlist) {
+        // commit() (synchronous) so the file exists before ensureReadable() chmods it.
+        prefs(context).edit().putStringSet(KEY_ALLOWLIST, new HashSet<>(allowlist)).commit();
+        ensureReadable(context);
+    }
+
+    /**
+     * Best-effort: make the prefs file (and its parent directory) world-readable so
+     * the system_server hook (a different uid) can read the same config file.
+     */
+    public static void ensureReadable(Context context) {
+        try {
+            File sharedPrefs = new File(context.getDataDir(), "shared_prefs");
+            Runtime.getRuntime().exec(new String[]{"chmod", "711", sharedPrefs.getAbsolutePath()});
+            Runtime.getRuntime().exec(new String[]{"chmod", "644",
+                    new File(sharedPrefs, PREF_NAME + ".xml").getAbsolutePath()});
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/HyperFCMLive/src/main/res/layout/activity_main.xml
+++ b/HyperFCMLive/src/main/res/layout/activity_main.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/hint"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="8dp"
+        android:text="@string/settings_hint"
+        android:textColor="?android:attr/textColorSecondary" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingBottom="8dp">
+
+        <Button
+            android:id="@+id/btn_select_all"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginEnd="4dp"
+            android:text="@string/select_all" />
+
+        <Button
+            android:id="@+id/btn_clear_all"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="4dp"
+            android:text="@string/clear_all" />
+    </LinearLayout>
+
+    <CheckBox
+        android:id="@+id/cb_system_apps"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/show_system_apps"
+        android:paddingBottom="8dp" />
+
+    <SearchView
+        android:id="@+id/search_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:queryHint="@string/search_hint"
+        android:iconifiedByDefault="false"
+        android:layout_marginBottom="8dp" />
+
+    <ListView
+        android:id="@+id/app_list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+</LinearLayout>

--- a/HyperFCMLive/src/main/res/layout/item_app.xml
+++ b/HyperFCMLive/src/main/res/layout/item_app.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:minHeight="56dp"
+    android:orientation="horizontal"
+    android:padding="8dp">
+
+    <ImageView
+        android:id="@+id/app_icon"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:contentDescription="@null" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_marginStart="12dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/app_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/app_pkg"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            android:textColor="?android:attr/textColorSecondary" />
+    </LinearLayout>
+
+    <CheckBox
+        android:id="@+id/app_check"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/HyperFCMLive/src/main/res/values-zh-rCN/strings.xml
+++ b/HyperFCMLive/src/main/res/values-zh-rCN/strings.xml
@@ -2,4 +2,10 @@
 <resources>
     <string name="app_name">修复澎湃系统谷歌推送重连</string>
     <string name="xposed_description">去除澎湃系统对谷歌推送连接相关广播的限制。启用模块后，系统耗电可能会增加。</string>
+    <string name="settings_title">FCM 唤醒白名单</string>
+    <string name="settings_hint">只有下方勾选的应用，才会被 FCM 推送唤醒 / 自动拉起。未勾选的应用不会被唤醒（即使已开启通知）。</string>
+    <string name="select_all">全选</string>
+    <string name="clear_all">清空</string>
+    <string name="search_hint">搜索应用…</string>
+    <string name="show_system_apps">显示系统应用</string>
 </resources>

--- a/HyperFCMLive/src/main/res/values/strings.xml
+++ b/HyperFCMLive/src/main/res/values/strings.xml
@@ -1,4 +1,10 @@
 <resources>
     <string name="app_name">Fix HyperOS FCM reconnection</string>
     <string name="xposed_description">Remove HyperOS\'s restrictions on FCM connection-related broadcasts. System power consumption may increase when this module is enabled.</string>
+    <string name="settings_title">FCM wake whitelist</string>
+    <string name="settings_hint">Only the apps checked below will be woken / auto-started by FCM pushes. Unchecked apps will not be woken, even if notifications are on.</string>
+    <string name="select_all">Select all</string>
+    <string name="clear_all">Clear all</string>
+    <string name="search_hint">Search apps…</string>
+    <string name="show_system_apps">Show system apps</string>
 </resources>


### PR DESCRIPTION
## 概述

为"允许 FCM 唤醒已停止应用"这一功能增加**手动白名单设置页**,让用户可以只允许指定的应用被 FCM 唤醒 / 自动拉起,而不是默认唤醒所有应用。

## 为什么

当前功能 2 对**所有** FCM 目标应用都生效——即使某个应用没开通知、用户并不希望它被拉起,它也会被唤醒/自动启动。手动白名单让用户可以精确控制。

## 行为语义(默认向后兼容)

- **未勾选任何应用(空白名单)= 保持现状,唤醒所有应用**(与原行为一致)。
- 勾选了至少一个应用后,才进入白名单模式:只唤醒勾选的应用。
- 这样对从未配置的用户是零行为变化。

## 改动内容

- 新增设置页 `MainActivity` + `AppListAdapter`,支持搜索、系统/用户应用切换、全选/清空;勾选的应用置顶。
- 新增 `Prefs` 配置读写(基于 libxposed 跨进程 `getRemotePreferences`,与 FCMFix 同方案,解决 system_server 跨进程读取被 SELinux 拦的问题)。
- `Hooker` 中门控唤醒逻辑:`FLAG_INCLUDE_STOPPED_PACKAGES` + 临时白名单 + `checkApplicationAutoStart` 均按白名单放行;空列表则全部放行。
- manifest:新增设置 Activity + `QUERY_ALL_PACKAGES` 权限(否则 Android 11+ 包可见性过滤导致列表不全)。
- `build.gradle`:启用 `io.github.libxposed:service` 依赖。

## 附带修复

- 热重载清理:重载前先卸载旧 hook,避免叠加导致"热重载失效"。
- 白名单刷新接收器改为懒注册,避免 system_server 启动早期 `IActivityManager` 为 null 时的 NPE。

## 说明

配置通过 libxposed 的跨进程 remote prefs 共享,改白名单即时生效,无需重启。不含任何本地环境/签名相关文件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)